### PR TITLE
Enum storage class

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -513,11 +513,8 @@ fn translate_expression(
                 _ => todo!(),
             }
         }
-        ir::Expression::LocalVariable(index) => {
-            (variables_ty[index].clone(), Expression::Variable(index))
-        }
-        ir::Expression::GlobalVariable(index) => {
-            (variables_ty[index].clone(), Expression::Variable(index))
+        ir::Expression::Variable(storage, index) => {
+            todo!();
         }
     }
 }

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -61,7 +61,7 @@ pub fn read_input(root_file_path: &Path, logger: &mut log::Logger) -> Result<ir:
             num_global_variables: 0,
         },
         global_builder: BlockBuilder::new(),
-        global_variables: Variables::new(false),
+        global_variables: Variables::new(ir::Storage::Global),
         exports: Vec::new(),
         files: Vec::new(),
         file_indices: HashMap::new(),
@@ -141,8 +141,7 @@ pub enum Item {
     Import(usize),
     Ty(ir::Ty),
     Function(Vec<ir::Function>),
-    GlobalVariable(usize),
-    LocalVariable(usize),
+    Variable(ir::Storage, usize),
 }
 
 impl Reader {

--- a/src/frontend/context.rs
+++ b/src/frontend/context.rs
@@ -299,7 +299,7 @@ impl Context {
                 logger,
             );
         }
-        local_variables.truncate(0, &mut builder, self);
+        local_variables.free_and_remove(0, &mut builder, self);
         let body = builder.finish();
         for ty_parameter_name in &ty_parameters_name {
             self.items.remove(ty_parameter_name);
@@ -408,7 +408,7 @@ impl Context {
                         logger,
                     );
                 }
-                variables.truncate(num_alive_variables, &mut then_builder, self);
+                variables.free_and_remove(num_alive_variables, &mut then_builder, self);
                 let then_block = then_builder.finish();
                 let mut else_builder = BlockBuilder::new();
                 if let Some(ast::ElseBlock {
@@ -432,7 +432,7 @@ impl Context {
                             logger,
                         );
                     }
-                    variables.truncate(num_alive_variables, &mut else_builder, self);
+                    variables.free_and_remove(num_alive_variables, &mut else_builder, self);
                 }
                 let else_block = else_builder.finish();
                 builder.add_if_statement(condition.unwrap(), then_block, else_block);
@@ -477,7 +477,7 @@ impl Context {
                         logger,
                     );
                 }
-                variables.truncate(num_alive_variables, &mut do_builder, self);
+                variables.free_and_remove(num_alive_variables, &mut do_builder, self);
                 let do_block = do_builder.finish();
                 builder.add_while_statement(condition.unwrap(), do_block);
             }

--- a/src/frontend/context.rs
+++ b/src/frontend/context.rs
@@ -187,7 +187,7 @@ impl Context {
             }
         }
         let mut builder = BlockBuilder::new();
-        let mut local_variables = Variables::new(true);
+        let mut local_variables = Variables::new(ir::Storage::Local);
         let mut parameters_ty = Vec::new();
         match ast_parameters {
             Ok(ast_parameters) => {
@@ -789,21 +789,8 @@ impl Context {
                     }))
                 }
             }
-            Item::GlobalVariable(index) => {
-                let expr = ir::Expression::GlobalVariable(index);
-                Ok(Term::Expression(if reference {
-                    expr
-                } else {
-                    ir::Expression::Function {
-                        candidates: vec![ir::Function::DereferenceInteger],
-                        calls: vec![ir::Call {
-                            arguments: vec![expr],
-                        }],
-                    }
-                }))
-            }
-            Item::LocalVariable(index) => {
-                let expr = ir::Expression::LocalVariable(index);
+            Item::Variable(storage, index) => {
+                let expr = ir::Expression::Variable(storage, index);
                 Ok(Term::Expression(if reference {
                     expr
                 } else {

--- a/src/frontend/variables.rs
+++ b/src/frontend/variables.rs
@@ -45,7 +45,12 @@ impl Variables {
         self.num += 1;
         ret
     }
-    pub fn truncate(&mut self, len: usize, builder: &mut BlockBuilder, context: &mut Context) {
+    pub fn free_and_remove(
+        &mut self,
+        len: usize,
+        builder: &mut BlockBuilder,
+        context: &mut Context,
+    ) {
         self.free(len, builder);
         for (name, index) in self.name_and_indices.split_off(len) {
             match context.items.remove(&name).unwrap() {

--- a/src/frontend/variables.rs
+++ b/src/frontend/variables.rs
@@ -20,15 +20,15 @@ use super::{BlockBuilder, Context, Item};
 use crate::ir;
 
 pub struct Variables {
-    is_local: bool,
+    storage: ir::Storage,
     num: usize,
     name_and_indices: Vec<(String, usize)>,
 }
 
 impl Variables {
-    pub fn new(is_local: bool) -> Variables {
+    pub fn new(storage: ir::Storage) -> Variables {
         Variables {
-            is_local,
+            storage,
             num: 0,
             name_and_indices: Vec::new(),
         }
@@ -41,11 +41,7 @@ impl Variables {
     }
     pub fn add(&mut self, name: String) -> Item {
         self.name_and_indices.push((name, self.num));
-        let ret = if self.is_local {
-            Item::LocalVariable(self.num)
-        } else {
-            Item::GlobalVariable(self.num)
-        };
+        let ret = Item::Variable(self.storage, self.num);
         self.num += 1;
         ret
     }
@@ -53,13 +49,9 @@ impl Variables {
         self.free(len, builder);
         for (name, index) in self.name_and_indices.split_off(len) {
             match context.items.remove(&name).unwrap() {
-                (_, Item::GlobalVariable(i)) => {
-                    assert!(!self.is_local);
-                    assert_eq!(index, i);
-                }
-                (_, Item::LocalVariable(i)) => {
-                    assert!(self.is_local);
-                    assert_eq!(index, i);
+                (_, Item::Variable(s, i)) => {
+                    assert_eq!(s, self.storage);
+                    assert_eq!(i, index);
                 }
                 _ => unreachable!(),
             }
@@ -67,11 +59,7 @@ impl Variables {
     }
     pub fn free(&mut self, len: usize, builder: &mut BlockBuilder) {
         for &(_, index) in self.name_and_indices[len..].iter().rev() {
-            let expr = if self.is_local {
-                ir::Expression::LocalVariable(index)
-            } else {
-                ir::Expression::GlobalVariable(index)
-            };
+            let expr = ir::Expression::Variable(self.storage, index);
             builder.add_expression(ir::Expression::Function {
                 candidates: vec![ir::Function::DeleteInteger],
                 calls: vec![ir::Call {

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -139,12 +139,18 @@ pub enum Expression {
     Integer(i32),
     Float(f64),
     String(String),
-    GlobalVariable(usize),
-    LocalVariable(usize),
+    Variable(Storage, usize),
     Function {
         candidates: Vec<Function>,
         calls: Vec<Call>,
     },
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[cfg_attr(test, derive(Serialize))]
+pub enum Storage {
+    Global,
+    Local,
 }
 
 #[cfg_attr(test, derive(Serialize))]

--- a/tests/frontend/break/expected.json
+++ b/tests/frontend/break/expected.json
@@ -30,7 +30,10 @@
                     {
                       "arguments": [
                         {
-                          "GlobalVariable": 0
+                          "Variable": [
+                            "Global",
+                            0
+                          ]
                         }
                       ]
                     }
@@ -51,7 +54,10 @@
                             {
                               "arguments": [
                                 {
-                                  "GlobalVariable": 1
+                                  "Variable": [
+                                    "Global",
+                                    1
+                                  ]
                                 }
                               ]
                             }
@@ -71,7 +77,10 @@
                                     {
                                       "arguments": [
                                         {
-                                          "GlobalVariable": 1
+                                          "Variable": [
+                                            "Global",
+                                            1
+                                          ]
                                         }
                                       ]
                                     }
@@ -101,7 +110,10 @@
                             {
                               "arguments": [
                                 {
-                                  "GlobalVariable": 2
+                                  "Variable": [
+                                    "Global",
+                                    2
+                                  ]
                                 }
                               ]
                             }
@@ -121,7 +133,10 @@
                                     {
                                       "arguments": [
                                         {
-                                          "GlobalVariable": 2
+                                          "Variable": [
+                                            "Global",
+                                            2
+                                          ]
                                         }
                                       ]
                                     }
@@ -137,7 +152,10 @@
                                     {
                                       "arguments": [
                                         {
-                                          "GlobalVariable": 1
+                                          "Variable": [
+                                            "Global",
+                                            1
+                                          ]
                                         }
                                       ]
                                     }
@@ -166,7 +184,10 @@
                             {
                               "arguments": [
                                 {
-                                  "GlobalVariable": 2
+                                  "Variable": [
+                                    "Global",
+                                    2
+                                  ]
                                 }
                               ]
                             }
@@ -182,7 +203,10 @@
                             {
                               "arguments": [
                                 {
-                                  "GlobalVariable": 1
+                                  "Variable": [
+                                    "Global",
+                                    1
+                                  ]
                                 }
                               ]
                             }
@@ -207,7 +231,10 @@
                     {
                       "arguments": [
                         {
-                          "GlobalVariable": 0
+                          "Variable": [
+                            "Global",
+                            0
+                          ]
                         }
                       ]
                     }

--- a/tests/frontend/operator_overload/expected.json
+++ b/tests/frontend/operator_overload/expected.json
@@ -113,7 +113,10 @@
                     {
                       "arguments": [
                         {
-                          "GlobalVariable": 0
+                          "Variable": [
+                            "Global",
+                            0
+                          ]
                         },
                         {
                           "Integer": 0
@@ -134,7 +137,10 @@
                     {
                       "arguments": [
                         {
-                          "GlobalVariable": 1
+                          "Variable": [
+                            "Global",
+                            1
+                          ]
                         },
                         {
                           "Integer": 1
@@ -161,7 +167,10 @@
                     {
                       "arguments": [
                         {
-                          "GlobalVariable": 0
+                          "Variable": [
+                            "Global",
+                            0
+                          ]
                         },
                         {
                           "Integer": 0
@@ -188,7 +197,10 @@
                     {
                       "arguments": [
                         {
-                          "GlobalVariable": 1
+                          "Variable": [
+                            "Global",
+                            1
+                          ]
                         },
                         {
                           "Integer": 1
@@ -215,7 +227,10 @@
                     {
                       "arguments": [
                         {
-                          "GlobalVariable": 2
+                          "Variable": [
+                            "Global",
+                            2
+                          ]
                         },
                         {
                           "Integer": 2
@@ -234,7 +249,10 @@
                     {
                       "arguments": [
                         {
-                          "GlobalVariable": 2
+                          "Variable": [
+                            "Global",
+                            2
+                          ]
                         }
                       ]
                     }
@@ -250,7 +268,10 @@
                     {
                       "arguments": [
                         {
-                          "GlobalVariable": 1
+                          "Variable": [
+                            "Global",
+                            1
+                          ]
                         }
                       ]
                     }
@@ -266,7 +287,10 @@
                     {
                       "arguments": [
                         {
-                          "GlobalVariable": 0
+                          "Variable": [
+                            "Global",
+                            0
+                          ]
                         }
                       ]
                     }

--- a/tests/frontend/variables/expected.json
+++ b/tests/frontend/variables/expected.json
@@ -47,7 +47,10 @@
                             {
                               "arguments": [
                                 {
-                                  "GlobalVariable": 1
+                                  "Variable": [
+                                    "Global",
+                                    1
+                                  ]
                                 },
                                 {
                                   "Integer": 1
@@ -64,7 +67,10 @@
                             {
                               "arguments": [
                                 {
-                                  "LocalVariable": 0
+                                  "Variable": [
+                                    "Local",
+                                    0
+                                  ]
                                 },
                                 {
                                   "Integer": 2
@@ -81,7 +87,10 @@
                             {
                               "arguments": [
                                 {
-                                  "LocalVariable": 1
+                                  "Variable": [
+                                    "Local",
+                                    1
+                                  ]
                                 },
                                 {
                                   "Integer": 3
@@ -100,7 +109,10 @@
                             {
                               "arguments": [
                                 {
-                                  "LocalVariable": 1
+                                  "Variable": [
+                                    "Local",
+                                    1
+                                  ]
                                 }
                               ]
                             }
@@ -125,7 +137,10 @@
                     {
                       "arguments": [
                         {
-                          "LocalVariable": 0
+                          "Variable": [
+                            "Local",
+                            0
+                          ]
                         }
                       ]
                     }
@@ -158,7 +173,10 @@
                             {
                               "arguments": [
                                 {
-                                  "GlobalVariable": 0
+                                  "Variable": [
+                                    "Global",
+                                    0
+                                  ]
                                 },
                                 {
                                   "Integer": 1
@@ -177,7 +195,10 @@
                             {
                               "arguments": [
                                 {
-                                  "GlobalVariable": 0
+                                  "Variable": [
+                                    "Global",
+                                    0
+                                  ]
                                 }
                               ]
                             }
@@ -202,7 +223,10 @@
                     {
                       "arguments": [
                         {
-                          "GlobalVariable": 1
+                          "Variable": [
+                            "Global",
+                            1
+                          ]
                         }
                       ]
                     }


### PR DESCRIPTION
Merge `ir::Expression::{GlobalVariable, LocalVariable}` and use `enum Storage { Global, Local }` instead.
Also renamed `Variables::truncate()` to `Variables::free_and_remove()`