### PR TITLE
Changed parse rules of block comments

### DIFF
--- a/src/frontend/parser/tests.rs
+++ b/src/frontend/parser/tests.rs
@@ -90,9 +90,19 @@ fn skip_comments() {
             \\ comment
             bar",
             r"foo
+            // \\ comment
+            | \\ comment \\
+            \\ comment
+            bar",
+            r"foo
             /// comment
             \\  comment
             \\\// comment
+            bar",
+            r"foo
+            //// comment
+            \\ \\  comment
+            \\\\ comment
             bar",
         ])
         .chain(std::iter::repeat(false).zip([

--- a/src/frontend/parser/tests.rs
+++ b/src/frontend/parser/tests.rs
@@ -79,42 +79,36 @@ macro_rules! pos {
 
 #[test]
 fn skip_comments() {
-    for (is_on_new_line, input) in std::iter::repeat(true)
+    for (case_index, (is_on_new_line, input)) in std::iter::repeat(true)
         .zip([
             "foo--comment\nbar",
             "foo/-comment-/\nbar",
             "foo\n/-comment-/bar",
             r"foo
             // comment
-            |  comment
+            // comment
             \\ comment
             bar",
             r"foo
-            ///  comment
-            | // comment
-            | |  comment
-            | \\ comment
-            \\\  comment
-            bar",
-            r"foo
-            ////   comment
-            | |    comment
-            | \\// comment
-            |   |  comment
-            \\  \\ comment
+            /// comment
+            \\  comment
+            \\\// comment
             bar",
         ])
         .chain(std::iter::repeat(false).zip([
+            "foo/-comment-/bar",
+            "foo/-com/-ment--/bar",
+            "foo/--com-/ment--/bar",
+            "foo/--com---ment---/bar",
             "foo/-com-//-ment-/bar",
-            "foo/-/-com-//-ment-/-/bar",
+            "foo/--comment/--/bar",
             "foo/-/comment-/bar",
-            "foo/-/-/comment-/--/bar",
-            "foo/-com//-ment-/-/bar",
             "foo/-com\nment-/bar",
         ]))
+        .enumerate()
     {
         let mut chars_peekable = CharsPeekable::new(&input);
-        let mut parser = Parser::new(&mut chars_peekable, 0).unwrap();
+        let mut parser = Parser::new(&mut chars_peekable, case_index).unwrap();
         assert_eq!(
             parser.current.token,
             Some(Token::Identifier(String::from("foo")))

--- a/src/log.rs
+++ b/src/log.rs
@@ -178,9 +178,7 @@ impl Logger {
 pub enum ParseError {
     /// Returned by [`read_token`](../frontend/ast/fn.read_token.html).
     UnexpectedCharacter(Pos),
-    /// Returned by
-    /// [`skip_block_comment`](../frontend/ast/fn.skip_block_comment.html).
-    UnterminatedComment(Vec<Pos>),
+    UnterminatedComment(Pos),
     /// Returned by [`read_token`](../frontend/ast/fn.read_token.html).
     UnterminatedStringLiteral(Pos),
     /// Returned by [`read_token`](../frontend/ast/fn.read_token.html).
@@ -267,12 +265,10 @@ impl Logger {
                 .unwrap();
                 self.quote(dollar_pos, files);
             }
-            ParseError::UnterminatedComment(comments_pos) => {
-                writeln!(self.err, "{}", files[comments_pos[0].file].path.display()).unwrap();
-                for pos in comments_pos {
-                    writeln!(self.err, "Unterminated comment at {pos}:").unwrap();
-                    self.quote(pos, files);
-                }
+            ParseError::UnterminatedComment(comment_pos) => {
+                writeln!(self.err, "{}", files[comment_pos.file].path.display()).unwrap();
+                writeln!(self.err, "Unterminated comment at {comment_pos}:").unwrap();
+                self.quote(comment_pos, files);
             }
             ParseError::InvalidBlockComment { start_pos } => {
                 writeln!(self.err, "{}", files[start_pos.file].path.display()).unwrap();


### PR DESCRIPTION
Closes #12.

Currently, block comments (`/- ... -/` and `//...` `\\...`) do not support including `/-` `-/` `//` `\\` inside a comment.
To allow nesting, we introduce a new rule:

- Use more hyphens (slashes and backslashes) for nesting: e.g. `///...` `\\\...` or `/--- ... ---/`
- The number of hyphens (slashes and backslashes) must match on both ends.

This preserves nesting support while making it possible to include URL inside comments.